### PR TITLE
Improved click handler overload

### DIFF
--- a/markdown-text/src/main/java/com/arnyminerz/markdowntext/MarkdownText.kt
+++ b/markdown-text/src/main/java/com/arnyminerz/markdowntext/MarkdownText.kt
@@ -98,16 +98,23 @@ fun MarkdownText(
                 val offset = layoutResult.getOffsetForPosition(pos)
                 text.getStringAnnotations(offset, offset)
                     .firstOrNull()
-                    .let { annotation -> onClick?.invoke(annotation) }
-                text.getStringAnnotations("link", offset, offset)
-                    .firstOrNull()
-                    ?.let { stringAnnotation ->
-                        try {
-                            if (onClick == null || !onClickOverrides)
+                    .let { stringAnnotation ->
+                        // If the annotation is a link, and there's no click listener, or onClickOverrides is false
+                        if (stringAnnotation?.tag == "link" && (onClick == null || !onClickOverrides)) {
+                            try {
+                                // Launch the link
                                 uriHandler.openUri(stringAnnotation.item)
-                        } catch (e: ActivityNotFoundException) {
-                            Log.w(TAG, "Could not find link handler.")
+                            } catch (e: ActivityNotFoundException) {
+                                Log.w(TAG, "Could not find a link handler.")
+                            }
+                        } else {
+                            // Otherwise, call the listener if not null
+                            onClick?.invoke(stringAnnotation)
                         }
+                    }
+                    ?: run {
+                        Log.w(TAG, "Tapped string without annotation")
+                        onClick?.invoke(null)
                     }
             }
         }


### PR DESCRIPTION
Closes #48. Implements the following cases:
1. If `onClick` is `null`:
    * Clicking on links will launch them with the browser.
2. If `onClick` is not `null`:
    * If `onClickOverrides` is `false`:
        * Tapping a link will launch it.
        * Tapping something else will call `onClick`
    * If `onClickOverrides` is `true`:
        * Tapping anything will call `onClick`